### PR TITLE
Adicionado um #define para "SDL_MAIN_HANDLED"

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#define SDL_MAIN_HANDLED
 #include "cacheta.hpp"
 #include "exception.hpp"
 


### PR DESCRIPTION
Adicionado um #define para "SDL_MAIN_HANDLED" no main.cpp, pois, no Windows, dava símbolo indefinido na main