### PR TITLE
Novos métodos em Grid

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "iosfwd": "cpp",
+        "sstream": "cpp"
+    }
+}

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -68,15 +68,23 @@ void Cacheta::poll_event(SDL_Event *e) {
             if(e->key.keysym.sym == SDLK_p) {
                screen_shot(); 
             }
+            if(e->key.keysym.sym == SDLK_d) {
+                Grid *g = dynamic_cast<Grid*>(*(renders.begin()));
+                Render *r = g->remove_render(24, 2);
+                if(r) {
+                   delete r;
+                }               
+            }            
             break;
         }
         case SDL_MOUSEBUTTONDOWN: {
-            // ao clicar com o mouse, pego o grid (primeiro elemento)
-            // e adiciono um rectangulo 2 pixels maior em todas as direções
-            RendersI i = renders.begin();
-            SDL_Rect grid_rect;           
-            (*i)->get_inflate_rect(grid_rect, 2);                        
-            add_rectangle(grid_rect, {0xFF, 0x00, 0x00, 0x00}, false);
+            Grid *g = dynamic_cast<Grid*>(*(renders.begin()));
+            Render *r = g->get_render(25, 3);
+            if(r) {
+                SDL_Rect rect;           
+                r->get_inflate_rect(rect, 2);                        
+                add_rectangle(rect, {0xFF, 0x00, 0x00, 0x00}, false);
+            }
             break;
         }
         case SDL_MOUSEWHEEL: {

--- a/render.cpp
+++ b/render.cpp
@@ -497,7 +497,8 @@ void Grid::add_retangle(int col, int row, const SDL_Color &color, bool fill) {
     SDL_Rect rect;
     get_cell_rect(col, row, rect);
     Rectangle *p = new Rectangle(window_renderer, rect, color, fill);
-    renders.push_back(p);    
+    renders.push_back(p);
+    map_renders[col][row] = p;
 }
 
 //-----------------------------------------------------------------------------
@@ -506,6 +507,7 @@ void Grid::add_texture(int col, int row, const string& file_name) {
     get_cell_rect(col, row, rect);    
     Texture *p = new Texture(window_renderer, file_name, rect.x, rect.y);
     renders.push_back(p);
+    map_renders[col][row] = p;
 }    
 
 
@@ -588,5 +590,22 @@ void Grid::get_rect(SDL_Rect &rect) {
     rect.y = min_y;
     rect.w = max_x - min_x;
     rect.h = max_y - min_y;
+}
+
+//-----------------------------------------------------------------------------
+Render *Grid::get_render(int col, int row) {
+    Render *result = map_renders[col][row];
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+Render *Grid::remove_render(int col, int row) {
+    Render *result = get_render(col, row);
+    map_renders[col][row] = NULL;
+    RendersI position = find(renders.begin(), renders.end(), result);
+    if(position != renders.end())  {
+        renders.erase(position);
+    }
+    return result;
 }
 

--- a/render.hpp
+++ b/render.hpp
@@ -148,14 +148,13 @@ public:
     void add_retangle(int col, int row, const SDL_Color &color, bool fill);
     void add_texture(int col, int row, const string& file_name);
     Render *remove_render(int col, int row);
-
+    Render *get_render(int col, int row);
 public:
     void render(void);    
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);  
-    void get_rect(SDL_Rect &rect); 
-    Render *get_render(int col, int row); 
+    void get_rect(SDL_Rect &rect);    
 private:
     int cols;
     int rows;

--- a/render.hpp
+++ b/render.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 
@@ -146,13 +147,15 @@ public:
     void get_cell_rect(int col, int row, SDL_Rect &rect);
     void add_retangle(int col, int row, const SDL_Color &color, bool fill);
     void add_texture(int col, int row, const string& file_name);
+    Render *remove_render(int col, int row);
 
 public:
     void render(void);    
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);  
-    void get_rect(SDL_Rect &rect);  
+    void get_rect(SDL_Rect &rect); 
+    Render *get_render(int col, int row); 
 private:
     int cols;
     int rows;
@@ -163,6 +166,7 @@ private:
     int vpad;
     int hpad;
     Renders renders;
+    map<int, map<int, Render*> > map_renders;
 };
 
 #endif


### PR DESCRIPTION
`get_render` pega o objeto render pelo col row, retorna null se não existir;
`remove_render` remove do grid o render pelo col row - não libera a memória.