### PR TITLE
Nova função get_render_at

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -155,3 +155,18 @@ void App::screen_shot(void) {
     SDL_FreeSurface(ss);
 }
 
+//-----------------------------------------------------------------------------
+Render *App::get_render_at(int x, int y) {
+    for(auto r : renders) {
+        const Renders &rs = r->get_renders();
+        for (RendersCRI i = rs.rbegin(); i != rs.rend(); i++) {
+            if((*i)->rect_contains(x, y)) {
+                return *i;
+            }
+        }
+        if(r->rect_contains(x, y)) {
+            return r;
+        }        
+    }
+    return NULL;
+}

--- a/app.hpp
+++ b/app.hpp
@@ -34,6 +34,7 @@ protected:
             int vpad, int hpad, 
             const SDL_Color &color
         );
+    Render *get_render_at(int x, int y);
 private:
     SDL_Window* window; 
     int width;

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -68,13 +68,24 @@ void Cacheta::poll_event(SDL_Event *e) {
             if(e->key.keysym.sym == SDLK_p) {
                screen_shot(); 
             }
-            if(e->key.keysym.sym == SDLK_d) {
-                Grid *g = dynamic_cast<Grid*>(*(renders.begin()));
-                Render *r = g->remove_render(24, 2);
-                if(r) {
-                   delete r;
-                }               
-            }            
+
+            // `renders.begin()`: o grid é o primeiro elemento
+            // `get_renders()`: pega o vector de renders do grid sem precisar de cast
+            // movimenta todos os elementos do grid usando um foreach
+            if(e->key.keysym.sym == SDLK_d) { /* down */                
+                const Renders &rs = (*(renders.begin()))->get_renders();
+                for (auto i : rs) {
+                    i->move(0, 8);    
+                }
+            }
+            if(e->key.keysym.sym == SDLK_u) { /* up */
+                const Renders &rs = (*(renders.begin()))->get_renders();
+                for (auto i : rs) {
+                    i->move(0, -8);    
+                }
+            }
+                
+         
             break;
         }
         case SDL_MOUSEBUTTONDOWN: {
@@ -108,15 +119,16 @@ void Cacheta::poll_event(SDL_Event *e) {
             break;
         }
         case SDL_MOUSEMOTION: {
-            if(!renders.empty()) {
-                
-                // movimenta o Grid
-                // ele é o primeiro elemento neste exemplo
 
-                RendersI i = renders.begin();                
-                (*i)->set_xy(e->motion.x, e->motion.y);
-
+            Render *r = get_render_at(e->motion.x, e->motion.y);
+            if(r) {
+                Texture *t = dynamic_cast<Texture*>(r);
+                if(t) {
+                    t->set_color(0xFF, 0xDD, 0xDD);    
+                }
             }
+        
+
             break;
         }
     }

--- a/render.cpp
+++ b/render.cpp
@@ -32,10 +32,27 @@ void Render::set_xy(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Render::get_inflate_rect(SDL_Rect &rect, int amount) {
+void Render::get_inflate_rect(SDL_Rect &rect, int amount) const {
     get_rect(rect);
     inflate_rect(rect, amount);
 }
+
+//-----------------------------------------------------------------------------
+const Renders& Render::get_renders(void) const {
+    return renders;
+}
+
+//-----------------------------------------------------------------------------
+bool Render::rect_contains(int x, int y) const {
+    SDL_Rect rect;
+    get_rect(rect);
+    return (rect.x <= x) && 
+           (rect.y <= y) && 
+           ((rect.x+rect.w) >= x) &&
+           ((rect.y+rect.h) >= y);
+}
+
+
 
 //-----------------------------------------------------------------------------
 //- Texture -------------------------------------------------------------------
@@ -83,7 +100,7 @@ void Texture::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Texture::get_rect(SDL_Rect &rect) {
+void Texture::get_rect(SDL_Rect &rect) const {
     rect.x = this->rect.x;
     rect.y = this->rect.y;
     rect.w = this->rect.w;
@@ -148,7 +165,7 @@ void Rectangle::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Rectangle::get_rect(SDL_Rect &rect) {
+void Rectangle::get_rect(SDL_Rect &rect) const {
     rect.x = this->rect.x;
     rect.y = this->rect.y;
     rect.w = this->rect.w;
@@ -196,7 +213,7 @@ void Line::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Line::get_rect(SDL_Rect &rect) {
+void Line::get_rect(SDL_Rect &rect) const {
     rect.x = this->point1.x;
     rect.y = this->point1.y;
     rect.w = this->point2.x - this->point1.x + 1;
@@ -250,7 +267,7 @@ void Lines::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Lines::get_rect(SDL_Rect &rect) {
+void Lines::get_rect(SDL_Rect &rect) const {
 
     int min_x = numeric_limits<int>::max();
     int min_y = numeric_limits<int>::max();
@@ -307,7 +324,7 @@ void Point::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Point::get_rect(SDL_Rect &rect) {
+void Point::get_rect(SDL_Rect &rect) const {
     rect.x = point.x;
     rect.y = point.y;
     rect.w = 1;
@@ -374,7 +391,7 @@ void Rectangles::get_xy(int &x, int &y) {
 }
 
 //-----------------------------------------------------------------------------
-void Rectangles::get_rect(SDL_Rect &rect) {
+void Rectangles::get_rect(SDL_Rect &rect) const {
 
     int min_x = numeric_limits<int>::max();
     int min_y = numeric_limits<int>::max();
@@ -441,7 +458,7 @@ void Points::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Points::get_rect(SDL_Rect &rect) {
+void Points::get_rect(SDL_Rect &rect) const {
 
     int min_x = numeric_limits<int>::max();
     int min_y = numeric_limits<int>::max();
@@ -587,7 +604,7 @@ void Grid::move(int x, int y) {
 }
 
 //-----------------------------------------------------------------------------
-void Grid::get_rect(SDL_Rect &rect) {
+void Grid::get_rect(SDL_Rect &rect) const {
 
     int min_x = numeric_limits<int>::max();
     int min_y = numeric_limits<int>::max();

--- a/render.hpp
+++ b/render.hpp
@@ -14,12 +14,14 @@ class Render;
 typedef vector<Render*> Renders;
 typedef Renders::iterator RendersI;
 typedef Renders::reverse_iterator RendersRI;
+typedef Renders::const_reverse_iterator RendersCRI;
 
 void inflate_rect(SDL_Rect &rect, int amount);
 
 class Render {
 protected:
     SDL_Renderer* window_renderer;
+    Renders renders;
 public:
     Render(SDL_Renderer* window_renderer);
     virtual ~Render();
@@ -29,9 +31,11 @@ public:
     virtual void set_x(int x) = 0;
     virtual void set_y(int y) = 0;
     virtual void move(int x, int y) = 0;
-    virtual void get_rect(SDL_Rect &rect) = 0;
+    virtual void get_rect(SDL_Rect &rect) const = 0;
     void set_xy(int x, int y);
-    void get_inflate_rect(SDL_Rect &rect, int amount);    
+    void get_inflate_rect(SDL_Rect &rect, int amount) const;
+    const Renders& get_renders() const;
+    bool rect_contains(int x, int y) const;
 };
 
 class Texture : public Render {
@@ -44,7 +48,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);
-    void get_rect(SDL_Rect &rect);
+    void get_rect(SDL_Rect &rect) const;
     void set_blend(SDL_BlendMode mode);
     void set_alpha(Uint8 alpha);
     void set_color(Uint8 r, Uint8 g, Uint8 b);
@@ -62,7 +66,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y); 
-    void get_rect(SDL_Rect &rect);   
+    void get_rect(SDL_Rect &rect) const;   
 private:
     bool fill;    
 };
@@ -77,7 +81,7 @@ public:
     void set_y(int y);
     void move(int x, int y);
     void get_xy(int &x, int &y);
-    void get_rect(SDL_Rect &rect);
+    void get_rect(SDL_Rect &rect) const;
 protected:
     vector<SDL_Rect>rects;
 private:
@@ -94,7 +98,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);
-    void get_rect(SDL_Rect &rect);        
+    void get_rect(SDL_Rect &rect) const;        
 };
 
 class Lines : public Render {
@@ -106,7 +110,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);
-    void get_rect(SDL_Rect &rect);       
+    void get_rect(SDL_Rect &rect) const;       
 private:
     vector<SDL_Point> points;
 };
@@ -121,7 +125,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);
-    void get_rect(SDL_Rect &rect);         
+    void get_rect(SDL_Rect &rect) const;         
 };
 
 class Points : public Render {
@@ -133,7 +137,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);
-    void get_rect(SDL_Rect &rect);      
+    void get_rect(SDL_Rect &rect) const;
 private:
     vector<SDL_Point>points;    
 };
@@ -157,7 +161,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);  
-    void get_rect(SDL_Rect &rect);    
+    void get_rect(SDL_Rect &rect) const;    
 private:
     int cols;
     int rows;
@@ -166,8 +170,7 @@ private:
     int vline_size;
     int hline_size;
     int vpad;
-    int hpad;
-    Renders renders;
+    int hpad;    
     map<int, map<int, Render*> > map_renders;
 };
 


### PR DESCRIPTION
Recebe x, y como argumento e retorna o render, ou nulo se não houver. 

Algumas funções membro ganharam o modificador const. 

Em cacheta.cpp exemplo de uso, colorindo a carta quando passa o mouse. 

Em cacheta.cpp, Utilizando o renders que foi movido para a classe base\ para acessar todos os elementos do grid em um foreach.

Estas modificações tem por objetivo apoiar o tratamento dos eventos move do mouse.