### PR TITLE
Mouse over, leave, click e doble click

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -58,7 +58,36 @@ void App::loop(void) {
 
 //-----------------------------------------------------------------------------
 void App::poll_event(SDL_Event *e) {
-
+    switch(e->type) {
+        case SDL_MOUSEMOTION: {            
+            static Render *last_render = NULL;
+            Render *r = get_render_at(e->motion.x, e->motion.y);            
+            if((r) && (last_render != r)) {
+                r->mouse_over();
+            }            
+            if((last_render) && (last_render != r)) {
+                last_render->mouse_leave();
+            }
+            last_render = r;
+            break;
+        }
+        case SDL_MOUSEBUTTONDOWN: {
+            switch(e->button.button) {
+                case SDL_BUTTON_LEFT: {
+                    Render *r = get_render_at(e->button.x, e->button.y);
+                    if(r) {
+                        if(e->button.clicks == 1) {
+                            r->mouse_click();
+                        } else if(e->button.clicks == 2) {
+                            r->mouse_dclick();
+                        }
+                    }
+                    break;
+                }
+            }
+            break;
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -168,5 +197,5 @@ Render *App::get_render_at(int x, int y) {
             return r;
         }        
     }
-    return NULL;
+    return nullptr;
 }

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -48,8 +48,36 @@ Cacheta::Cacheta() : App("Cacheta 1.0", 800, 600) {
     grid->add_retangle( 9, 1, {0xFF, 0xFF, 0x00, 0x00}, true);
     grid->add_retangle(10, 1, {0xFF, 0x00, 0xFF, 0x00}, true);
     grid->add_retangle( 9, 2, {0x00, 0xFF, 0xFF, 0x00}, false);
+    //====================================================
 
-    //====================================================     
+    const Renders &rs = grid->get_renders();
+    for (auto i : rs) {
+        i->on_mouse_over = [](Render *r) {
+            Texture *t = dynamic_cast<Texture*>(r);
+            if(t) {
+                t->set_color(0xFF, 0xDD, 0xDD);                
+            }            
+        };
+        i->on_mouse_leave = [](Render *r) {
+            Texture *t = dynamic_cast<Texture*>(r);
+            if(t) {
+                t->set_color(0xFF, 0xFF, 0xFF);    
+            }            
+        };
+        i->on_mouse_click = [](Render *r) {
+            Texture *t = dynamic_cast<Texture*>(r);
+            if(t) {
+                t->set_color(0x77, 0x77, 0xFF);    
+            }            
+        };
+        i->on_mouse_dclick = [](Render *r) {
+            Grid *owner_grid = dynamic_cast<Grid*>(r->owner);
+            if(owner_grid) {
+                Render *rd = owner_grid->remove_render(r);
+                delete rd;
+            }
+        };
+    }
 
 }
 
@@ -68,67 +96,15 @@ void Cacheta::poll_event(SDL_Event *e) {
             if(e->key.keysym.sym == SDLK_p) {
                screen_shot(); 
             }
-
-            // `renders.begin()`: o grid é o primeiro elemento
-            // `get_renders()`: pega o vector de renders do grid sem precisar de cast
-            // movimenta todos os elementos do grid usando um foreach
-            if(e->key.keysym.sym == SDLK_d) { /* down */                
-                const Renders &rs = (*(renders.begin()))->get_renders();
-                for (auto i : rs) {
-                    i->move(0, 8);    
-                }
-            }
-            if(e->key.keysym.sym == SDLK_u) { /* up */
-                const Renders &rs = (*(renders.begin()))->get_renders();
-                for (auto i : rs) {
-                    i->move(0, -8);    
-                }
-            }
-                
-         
             break;
         }
         case SDL_MOUSEBUTTONDOWN: {
-            Grid *g = dynamic_cast<Grid*>(*(renders.begin()));
-            Render *r1 = g->get_render(25, 3);
-            Render *r2 = g->get_render(0, 7);
-            if(r1 && r2) {
-                Texture *t1 = dynamic_cast<Texture*>(r1);
-                Texture *t2 = dynamic_cast<Texture*>(r2);
-                if(t1 && t2) {
-                    static bool b = true;                    
-                    if(b) {
-                        t1->set_alpha(0xEE);
-                        t1->set_color(0xFF, 0xDD, 0xDD);
-
-                        t2->set_blend(SDL_BLENDMODE_MOD);
-
-                    } else {
-                        t1->set_alpha(0xFF);
-                        t1->set_color(0xFF, 0xFF, 0xFF);
-                        
-                        t2->set_blend(SDL_BLENDMODE_BLEND);
-                    }
-                    b = !b;
-                }
-            }
             break;
         }
         case SDL_MOUSEWHEEL: {
-
             break;
         }
         case SDL_MOUSEMOTION: {
-
-            Render *r = get_render_at(e->motion.x, e->motion.y);
-            if(r) {
-                Texture *t = dynamic_cast<Texture*>(r);
-                if(t) {
-                    t->set_color(0xFF, 0xDD, 0xDD);    
-                }
-            }
-        
-
             break;
         }
     }

--- a/render.hpp
+++ b/render.hpp
@@ -26,6 +26,7 @@ public:
     Render(SDL_Renderer* window_renderer);
     virtual ~Render();
 public:
+    Render *owner;
     SDL_Color color;
     virtual void render(void) = 0;
     virtual void set_x(int x) = 0;
@@ -36,6 +37,15 @@ public:
     void get_inflate_rect(SDL_Rect &rect, int amount) const;
     const Renders& get_renders() const;
     bool rect_contains(int x, int y) const;
+    void mouse_over(void);
+    void mouse_leave(void);
+    void mouse_click(void);
+    void mouse_dclick(void);
+public:
+    void (*on_mouse_over)(Render*);
+    void (*on_mouse_leave)(Render*);
+    void (*on_mouse_click)(Render*);
+    void (*on_mouse_dclick)(Render*);
 };
 
 class Texture : public Render {
@@ -80,7 +90,7 @@ public:
     void set_x(int x);
     void set_y(int y);
     void move(int x, int y);
-    void get_xy(int &x, int &y);
+    void get_xy(int &x, int &y) const;
     void get_rect(SDL_Rect &rect) const;
 protected:
     vector<SDL_Rect>rects;
@@ -151,10 +161,12 @@ public:
          const SDL_Color &color);
     ~Grid();
 public:
-    void get_cell_rect(int col, int row, SDL_Rect &rect);
+    void get_cell_rect(int col, int row, SDL_Rect &rect) const;
     void add_retangle(int col, int row, const SDL_Color &color, bool fill);
     void add_texture(int col, int row, const string& file_name);
     Render *remove_render(int col, int row);
+    Render *remove_render(Render *render);
+    bool get_render_cell(const Render *render, int &col, int &row) const;
     Render *get_render(int col, int row);
 public:
     void render(void);    


### PR DESCRIPTION
Com esta modificação é possível ligar aos objetos render os eventos:

on_mouse_over - quando o apontador do mouse entra no render;
on_mouse_leave - quando o apontador sai do render;
on_mouse_click - clique do esquerdo
on_mouse_dclick - duplo clique com esquerdo

Agora é possível através de um render saber se ele pertence a um grid (owner).
Também é possível descobrir a coordenada col, row de um render em um grid (get_render_cell).
Também é possível remover um render de um grid, somente passando o pointer do render como argumento.

