### PR TITLE
Ajustes diversos pós debug get_render_at

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,12 @@
 {
     "files.associations": {
         "iosfwd": "cpp",
-        "sstream": "cpp"
+        "sstream": "cpp",
+        "array": "cpp",
+        "deque": "cpp",
+        "list": "cpp",
+        "string": "cpp",
+        "vector": "cpp",
+        "string_view": "cpp"
     }
 }

--- a/app.cpp
+++ b/app.cpp
@@ -101,12 +101,6 @@ void App::render(void) {
 }
 
 //-----------------------------------------------------------------------------
-void App::add_texture(const string& file_name, int x, int y) { 
-    Texture *p = new Texture(window_renderer, file_name, x, y);
-    renders.push_back(p);
-}
-
-//-----------------------------------------------------------------------------
 void App::render_renders(void) {
     for(RendersI i = renders.begin(); i != renders.end(); i++) {
         (*i)->render();                
@@ -119,38 +113,52 @@ void App::delete_renders(void) {
         delete (*i);                
     }     
 }
+
 //-----------------------------------------------------------------------------
-void App::add_rectangle(const SDL_Rect &rect, const SDL_Color &color, bool fill) {
+Texture *App::add_texture(const string& file_name, int x, int y) { 
+    Texture *p = new Texture(window_renderer, file_name, x, y);
+    renders.push_back(p);
+    return p;
+}
+
+//-----------------------------------------------------------------------------
+Rectangle *App::add_rectangle(const SDL_Rect &rect, const SDL_Color &color, bool fill) {
     Rectangle *p = new Rectangle(window_renderer, rect, color, fill);
     renders.push_back(p);
+    return p;
 }
 //-----------------------------------------------------------------------------
-void App::add_rectangles(const vector<SDL_Rect> &rects, const SDL_Color &color, bool fill) {
+Rectangles *App::add_rectangles(const vector<SDL_Rect> &rects, const SDL_Color &color, bool fill) {
     Rectangles *p = new Rectangles(window_renderer, rects, color, fill);
     renders.push_back(p);
+    return p;
 }
 
 //-----------------------------------------------------------------------------
-void App::add_line(const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color) {
+Line *App::add_line(const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color) {
     Line *p = new Line(window_renderer, point1, point2, color);
     renders.push_back(p);
+    return p;
 }
 
-void App::add_lines(const vector<SDL_Point> &points, const SDL_Color &color) {
+Lines *App::add_lines(const vector<SDL_Point> &points, const SDL_Color &color) {
     Lines *p = new Lines(window_renderer, points, color);
     renders.push_back(p);    
+    return p;
 }
 
 //-----------------------------------------------------------------------------
-void App::add_point(const SDL_Point &point, const SDL_Color &color) {
+Point *App::add_point(const SDL_Point &point, const SDL_Color &color) {
     Point *p = new Point(window_renderer, point, color);
     renders.push_back(p);
+    return p;
 }
 
 //-----------------------------------------------------------------------------
-void App::add_points(const vector<SDL_Point> &points, const SDL_Color &color) {
+Points *App::add_points(const vector<SDL_Point> &points, const SDL_Color &color) {
     Points *p = new Points(window_renderer, points, color);
     renders.push_back(p);
+    return p;
 }
 
 //-----------------------------------------------------------------------------
@@ -186,15 +194,15 @@ void App::screen_shot(void) {
 
 //-----------------------------------------------------------------------------
 Render *App::get_render_at(int x, int y) {
-    for(auto r : renders) {
-        const Renders &rs = r->get_renders();
+    for (RendersCRI r = renders.rbegin(); r != renders.rend(); r++) {
+        const Renders &rs = (*r)->get_renders();
         for (RendersCRI i = rs.rbegin(); i != rs.rend(); i++) {
             if((*i)->rect_contains(x, y)) {
                 return *i;
             }
         }
-        if(r->rect_contains(x, y)) {
-            return r;
+        if((*r)->rect_contains(x, y)) {
+            return *r;
         }        
     }
     return nullptr;

--- a/app.hpp
+++ b/app.hpp
@@ -20,13 +20,13 @@ public:
 protected:
     SDL_Renderer* window_renderer;
     Renders renders;    
-    void add_texture(const string& file_name, int x, int y);
-    void add_rectangle(const SDL_Rect &rect, const SDL_Color &color, bool fill);
-    void add_rectangles(const vector<SDL_Rect> &rects, const SDL_Color &color, bool fill);
-    void add_line(const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color);
-    void add_lines(const vector<SDL_Point> &points, const SDL_Color &color);
-    void add_point(const SDL_Point &point, const SDL_Color &color);
-    void add_points(const vector<SDL_Point> &points, const SDL_Color &color);
+    Texture *add_texture(const string& file_name, int x, int y);
+    Rectangle *add_rectangle(const SDL_Rect &rect, const SDL_Color &color, bool fill);
+    Rectangles *add_rectangles(const vector<SDL_Rect> &rects, const SDL_Color &color, bool fill);
+    Line *add_line(const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color);
+    Lines *add_lines(const vector<SDL_Point> &points, const SDL_Color &color);
+    Point *add_point(const SDL_Point &point, const SDL_Color &color);
+    Points *add_points(const vector<SDL_Point> &points, const SDL_Color &color);
     Grid *add_grid(
             int cols, int rows, 
             int col_size, int row_size, 

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -3,10 +3,18 @@
 //-----------------------------------------------------------------------------
 Cacheta::Cacheta() : App("Cacheta 1.0", 800, 600) {
 
-    int w, h;
-    SDL_RenderGetLogicalSize(window_renderer, &w, &h);   
+    void (*event_click)(Render*) = [](Render *r) {
+        Texture *t = dynamic_cast<Texture*>(r);
+        if(t) {
+            t->set_color(0x77, 0x77, 0xFF);    
+        }
+    };
 
-    //====================================================
+    for(int i = 0; i < 10; i++) {
+        Texture *texture = add_texture("image_teste.png", 100+(i*16), 150);
+        texture->on_mouse_click = event_click;  
+    }
+
     Grid *grid = 
     add_grid(
         24,     /* cols */
@@ -25,60 +33,9 @@ Cacheta::Cacheta() : App("Cacheta 1.0", 800, 600) {
         }
     );
     
-    // posiciona um grupo de cartas na vertical
-    grid->add_texture(0, 4, "image_teste.png");
-    grid->add_texture(0, 5, "image_teste.png");
-    grid->add_texture(0, 6, "image_teste.png");
-    grid->add_texture(0, 7, "image_teste.png");
-
-    // posiciona um grupo de cartas numa mesma linha
-    grid->add_texture(12, 6, "image_teste.png");
-    grid->add_texture(13, 6, "image_teste.png");
-    grid->add_texture(14, 6, "image_teste.png");
-    grid->add_texture(15, 6, "image_teste.png");
-
-    // posiciona um grupo de cartas na diagonal
-    grid->add_texture(22, 0, "image_teste.png");
-    grid->add_texture(23, 1, "image_teste.png");
-    grid->add_texture(24, 2, "image_teste.png");
-    grid->add_texture(25, 3, "image_teste.png"); 
-
-    // adiciona alguns retangulos coloridos
-    grid->add_retangle( 8, 1, {0xFF, 0x00, 0x00, 0x00}, true);
-    grid->add_retangle( 9, 1, {0xFF, 0xFF, 0x00, 0x00}, true);
-    grid->add_retangle(10, 1, {0xFF, 0x00, 0xFF, 0x00}, true);
-    grid->add_retangle( 9, 2, {0x00, 0xFF, 0xFF, 0x00}, false);
-    //====================================================
-
-    const Renders &rs = grid->get_renders();
-    for (auto i : rs) {
-        i->on_mouse_over = [](Render *r) {
-            Texture *t = dynamic_cast<Texture*>(r);
-            if(t) {
-                t->set_color(0xFF, 0xDD, 0xDD);                
-            }            
-        };
-        i->on_mouse_leave = [](Render *r) {
-            Texture *t = dynamic_cast<Texture*>(r);
-            if(t) {
-                t->set_color(0xFF, 0xFF, 0xFF);    
-            }            
-        };
-        i->on_mouse_click = [](Render *r) {
-            Texture *t = dynamic_cast<Texture*>(r);
-            if(t) {
-                t->set_color(0x77, 0x77, 0xFF);    
-            }            
-        };
-        i->on_mouse_dclick = [](Render *r) {
-            Grid *owner_grid = dynamic_cast<Grid*>(r->owner);
-            if(owner_grid) {
-                Render *rd = owner_grid->remove_render(r);
-                delete rd;
-            }
-        };
+    for(int i = 0; i < 10; i++) {
+      grid->add_texture(20, 4+i, "image_teste.png")->on_mouse_click = event_click;
     }
-
 }
 
 //-----------------------------------------------------------------------------

--- a/render.cpp
+++ b/render.cpp
@@ -563,23 +563,25 @@ void Grid::get_cell_rect(int col, int row, SDL_Rect &rect) const {
 }
 
 //-----------------------------------------------------------------------------
-void Grid::add_retangle(int col, int row, const SDL_Color &color, bool fill) {
+Rectangle *Grid::add_retangle(int col, int row, const SDL_Color &color, bool fill) {
     SDL_Rect rect;
     get_cell_rect(col, row, rect);
     Rectangle *p = new Rectangle(window_renderer, rect, color, fill);
     renders.push_back(p);
     map_renders[col][row] = p;
     p->owner = this;
+    return p;
 }
 
 //-----------------------------------------------------------------------------
-void Grid::add_texture(int col, int row, const string& file_name) { 
+Texture *Grid::add_texture(int col, int row, const string& file_name) { 
     SDL_Rect rect;
     get_cell_rect(col, row, rect);    
     Texture *p = new Texture(window_renderer, file_name, rect.x, rect.y);
     renders.push_back(p);
     map_renders[col][row] = p;
     p->owner = this;
+    return p;
 }    
 
 
@@ -685,7 +687,7 @@ Render *Grid::remove_render(int col, int row) {
 Render *Grid::remove_render(Render *render) {
     int col, row;
     get_render_cell(render, col, row);
-    remove_render(col, row);
+    return remove_render(col, row);
 }
 
 //-----------------------------------------------------------------------------

--- a/render.hpp
+++ b/render.hpp
@@ -162,8 +162,8 @@ public:
     ~Grid();
 public:
     void get_cell_rect(int col, int row, SDL_Rect &rect) const;
-    void add_retangle(int col, int row, const SDL_Color &color, bool fill);
-    void add_texture(int col, int row, const string& file_name);
+    Rectangle *add_retangle(int col, int row, const SDL_Color &color, bool fill);
+    Texture *add_texture(int col, int row, const string& file_name);
     Render *remove_render(int col, int row);
     Render *remove_render(Render *render);
     bool get_render_cell(const Render *render, int &col, int &row) const;


### PR DESCRIPTION
Métodos `add_render`de app agora retornam o objeto.
Em app, a posição das funções foi mudada para melhor agrupar. 
Em app, `get_render_at` precisava ler os render em ordem reversa. 
Em grid, as funções `add_render` agora retornam o objeto criado. 
Em cacheta, teste para verificar se get_render_at está de fato funcionando.

Estes ajustes tem por objetivo viabilizar a programação da classe Card.