### PR TITLE
Constructor de Render com App

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -46,6 +46,11 @@ App::~App() {
 }
 
 //-----------------------------------------------------------------------------
+SDL_Renderer* App::get_window_renderer(void) {
+    return window_renderer;
+}
+
+//-----------------------------------------------------------------------------
 void App::loop(void) {
     SDL_Event e; 
     bool quit = false; 
@@ -121,7 +126,7 @@ void App::delete_renders(void) {
 
 //-----------------------------------------------------------------------------
 Texture *App::add_texture(const string& file_name, int x, int y) { 
-    Texture *p = new Texture(window_renderer, file_name, x, y);
+    Texture *p = new Texture(this, file_name, x, y);
     renders.push_back(p);
     return p;
 }
@@ -129,47 +134,47 @@ Texture *App::add_texture(const string& file_name, int x, int y) {
 //-----------------------------------------------------------------------------
 Texture *App::add_texture_text(const string& ttf_file_name, const string& text,
         int x, int y, const SDL_Color &color, int font_size) {
-    Texture *p = new Texture(window_renderer, ttf_file_name, text, x, y, color, font_size);
+    Texture *p = new Texture(this, ttf_file_name, text, x, y, color, font_size);
     renders.push_back(p);
     return p;    
 }
 
 //-----------------------------------------------------------------------------
 Rectangle *App::add_rectangle(const SDL_Rect &rect, const SDL_Color &color, bool fill) {
-    Rectangle *p = new Rectangle(window_renderer, rect, color, fill);
+    Rectangle *p = new Rectangle(this, rect, color, fill);
     renders.push_back(p);
     return p;
 }
 //-----------------------------------------------------------------------------
 Rectangles *App::add_rectangles(const vector<SDL_Rect> &rects, const SDL_Color &color, bool fill) {
-    Rectangles *p = new Rectangles(window_renderer, rects, color, fill);
+    Rectangles *p = new Rectangles(this, rects, color, fill);
     renders.push_back(p);
     return p;
 }
 
 //-----------------------------------------------------------------------------
 Line *App::add_line(const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color) {
-    Line *p = new Line(window_renderer, point1, point2, color);
+    Line *p = new Line(this, point1, point2, color);
     renders.push_back(p);
     return p;
 }
 
 Lines *App::add_lines(const vector<SDL_Point> &points, const SDL_Color &color) {
-    Lines *p = new Lines(window_renderer, points, color);
+    Lines *p = new Lines(this, points, color);
     renders.push_back(p);    
     return p;
 }
 
 //-----------------------------------------------------------------------------
 Point *App::add_point(const SDL_Point &point, const SDL_Color &color) {
-    Point *p = new Point(window_renderer, point, color);
+    Point *p = new Point(this, point, color);
     renders.push_back(p);
     return p;
 }
 
 //-----------------------------------------------------------------------------
 Points *App::add_points(const vector<SDL_Point> &points, const SDL_Color &color) {
-    Points *p = new Points(window_renderer, points, color);
+    Points *p = new Points(this, points, color);
     renders.push_back(p);
     return p;
 }
@@ -180,7 +185,7 @@ Grid *App::add_grid(int cols, int rows, int col_size,
                    int vpad, int hpad, 
                    const SDL_Color &color) {
     Grid *p = new Grid(
-        window_renderer, 
+        this, 
         cols, 
         rows, 
         col_size, 
@@ -198,13 +203,13 @@ Grid *App::add_grid(int cols, int rows, int col_size,
 
 //-----------------------------------------------------------------------------
 Card *App::add_card(int card_id, int x, int y) {
-    Card *p = new Card(window_renderer, card_id, x, y);
+    Card *p = new Card(this, card_id, x, y);
     renders.push_back(p);
     return p;    
 }
 
 CardGroup *App::add_card_group(CardGroupDirection direction) {
-    CardGroup *p = new CardGroup(window_renderer, direction);
+    CardGroup *p = new CardGroup(this, direction);
     renders.push_back(p);
     return p;    
 }

--- a/app.hpp
+++ b/app.hpp
@@ -14,13 +14,14 @@ class App {
 public:
     App(const string& window_caption, int width, int heigth);
     ~App();
-public:    
+public:        
+    Renders renders;
+public:
+    SDL_Renderer* get_window_renderer(void);
     void loop(void);
     virtual void poll_event(SDL_Event *e);
     void screen_shot(void);
-protected:
-    SDL_Renderer* window_renderer;
-    Renders renders;    
+protected:       
     Texture *add_texture(const string& file_name, int x, int y);
     Texture *add_texture_text(const string& ttf_file_name, const string& text,
             int x, int y, const SDL_Color &color, int font_size
@@ -43,6 +44,7 @@ protected:
     Render *get_render_at(int x, int y);
 private:
     SDL_Window* window; 
+    SDL_Renderer* window_renderer;
     int width;
     int heigth;
 private:

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -19,11 +19,38 @@ Cacheta::Cacheta() : App("Cacheta 1.0", 800, 600) {
         }
     }     
 
-    add_texture_text(
+    Texture *btn1 = add_texture_text(
         "28 Days Later.ttf", 
-        "CACHETA", 
-        100, 10, {0xFF, 0xFF, 0xFF, 0xFF}, 96
-    );   
+        "MOVE BAIXO", 
+        10, 10, {0x00, 0x00, 0xFF, 0xFF}, 48
+    );
+    void (*btn1_click)(Render*) = [](Render *r) {
+        App *app = r->app;
+        CardGroup *group_source = dynamic_cast<CardGroup*>(app->renders[0]);
+        CardGroup *group_dest = dynamic_cast<CardGroup*>(app->renders[1]);
+
+        Card *removed_card = dynamic_cast<Card*>(group_source->remove_render(*(group_source->get_renders().rbegin())));        
+        group_dest->add_card(removed_card);       
+
+    };
+    btn1->on_mouse_click = btn1_click;
+
+    Texture *btn2 = add_texture_text(
+        "28 Days Later.ttf", 
+        "MOVE CIMA", 
+        350, 10, {0xFF, 0x00, 0x00, 0xFF}, 48
+    );
+    void (*btn2_click)(Render*) = [](Render *r) {
+        App *app = r->app;
+        CardGroup *group_source = dynamic_cast<CardGroup*>(app->renders[1]);
+        CardGroup *group_dest = dynamic_cast<CardGroup*>(app->renders[0]);
+
+        Card *removed_card = dynamic_cast<Card*>(group_source->remove_render(*(group_source->get_renders().rbegin())));
+        group_dest->add_card(removed_card);       
+
+    };
+    btn2->on_mouse_click = btn2_click;
+
 }
 
 //-----------------------------------------------------------------------------

--- a/card.cpp
+++ b/card.cpp
@@ -1,8 +1,8 @@
 #include "card.hpp"
 
 //-----------------------------------------------------------------------------
-Card::Card(SDL_Renderer* window_renderer, int card_id, int x, int y) 
-     :Texture(window_renderer, determine_file_name(card_id), x, y) {
+Card::Card(App *app, int card_id, int x, int y) 
+     :Texture(app, determine_file_name(card_id), x, y) {
     
     void (*event_click)(Render*) = [](Render *r) {
         Card *c = dynamic_cast<Card*>(r);
@@ -40,14 +40,13 @@ bool Card::get_selected(void) {
 //-----------------------------------------------------------------------------
 //- CardGroup -----------------------------------------------------------------
 //-----------------------------------------------------------------------------
-CardGroup::CardGroup(SDL_Renderer* window_renderer, CardGroupDirection direction) 
-    : Grid(window_renderer, 0, 0, 18, 24, 0, 0, 0, 0, SDL_Color()) {
+CardGroup::CardGroup(App *app, CardGroupDirection direction) 
+    : Grid(app, 0, 0, 18, 24, 0, 0, 0, 0, SDL_Color()) {
     this->direction = direction;
 }
 
 //-----------------------------------------------------------------------------
-Card *CardGroup::add_card(int card_id) {
-    int col, row;
+void CardGroup::inc_col_row(int &col, int &row, SDL_Rect &rect) {
     switch(direction) {
         case Vertical: {
             col = 0;
@@ -60,12 +59,32 @@ Card *CardGroup::add_card(int card_id) {
             break;
         }
     }
+    get_cell_rect(col, row, rect);
+}
+
+//-----------------------------------------------------------------------------
+Card *CardGroup::add_card(int card_id) {
+    int col, row;
     SDL_Rect rect;
-    get_cell_rect(col, row, rect);    
-    Card *p = new Card(window_renderer, card_id, rect.x, rect.y);
-    renders.push_back(p);
-    map_renders[col][row] = p;
-    p->owner = this;
-    return p;    
+    inc_col_row(col, row, rect);
+    Card *card = new Card(app, card_id, rect.x, rect.y);
+    return add(card, col, row);    
+}
+
+//-----------------------------------------------------------------------------
+Card *CardGroup::add_card(Card *card) {
+    int col, row;
+    SDL_Rect rect;
+    inc_col_row(col, row, rect);    
+    card->set_xy(rect.x, rect.y);    
+    return add(card, col, row);
+}
+
+//-----------------------------------------------------------------------------
+Card *CardGroup::add(Card *card, int col, int row) {
+    renders.push_back(card);
+    map_renders[col][row] = card;
+    card->owner = this; 
+    return card;   
 }
 

--- a/card.hpp
+++ b/card.hpp
@@ -10,7 +10,7 @@ enum CardGroupDirection {
 
 class Card: public Texture {
 public:
-    Card(SDL_Renderer* window_renderer, int card_id, int x, int y);
+    Card(App *app, int card_id, int x, int y);
 public:
     void set_selected(bool selected);
     bool get_selected(void);
@@ -21,11 +21,14 @@ private:
 
 class CardGroup: public Grid {
 public:
-    CardGroup(SDL_Renderer* window_renderer, CardGroupDirection direction);
+    CardGroup(App *app, CardGroupDirection direction);
 public:
-    Card *add_card(int card_id);    
+    Card *add_card(int card_id);
+    Card *add_card(Card *card);
 private:
-    CardGroupDirection direction;        
+    CardGroupDirection direction; 
+    void inc_col_row(int &col, int &row, SDL_Rect &rect);
+    Card *add(Card *card, int col, int row);
 };
 
 #endif

--- a/render.cpp
+++ b/render.cpp
@@ -1,5 +1,6 @@
 #include "render.hpp"
 #include "exception.hpp"
+#include "app.hpp"
 #include <string>
 #include <algorithm>
 #include <limits>
@@ -16,13 +17,13 @@ void inflate_rect(SDL_Rect &rect, int amount) {
 //-----------------------------------------------------------------------------
 //- Render --------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Render::Render(SDL_Renderer* window_renderer) {
+Render::Render(App *app) {
     on_mouse_over = nullptr;
     on_mouse_leave = nullptr;
     on_mouse_click = nullptr;
     on_mouse_dclick = nullptr;
     owner = nullptr;
-    this->window_renderer = window_renderer;
+    this->app = app;
 }
 
 //-----------------------------------------------------------------------------
@@ -95,8 +96,8 @@ void Render::mouse_dclick(void) {
 //-----------------------------------------------------------------------------
 //- Texture -------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Texture::Texture(SDL_Renderer* window_renderer, const string& file_name, int x, int y) 
-    : Render(window_renderer) {    
+Texture::Texture(App *app, const string& file_name, int x, int y) 
+    : Render(app) {    
     SDL_Surface* temp_surface = IMG_Load(file_name.c_str());
     if(!temp_surface) {
         throw Exception("Não foi possível carregar a imagem " + file_name, IMG_GetError());
@@ -104,7 +105,7 @@ Texture::Texture(SDL_Renderer* window_renderer, const string& file_name, int x, 
     SDL_GetClipRect(temp_surface, &rect);
     rect.x = x;
     rect.y = y;
-    texture = SDL_CreateTextureFromSurface(this->window_renderer, temp_surface);
+    texture = SDL_CreateTextureFromSurface(app->get_window_renderer(), temp_surface);
     if(!texture) {
         throw Exception("Não foi possível criar a textura " + file_name, SDL_GetError());
     }
@@ -112,10 +113,10 @@ Texture::Texture(SDL_Renderer* window_renderer, const string& file_name, int x, 
 }
 
 //-----------------------------------------------------------------------------
-Texture::Texture(SDL_Renderer* window_renderer, 
+Texture::Texture(App *app, 
         const string& ttf_file_name, const string& text,
         int x, int y, const SDL_Color &color, int font_size) 
-    : Render(window_renderer) {
+    : Render(app) {
     TTF_Font* font = TTF_OpenFont(ttf_file_name.c_str(), font_size);
     if(!font) {
         throw Exception("Não foi possível carregar a fonte " + ttf_file_name, TTF_GetError());    
@@ -127,7 +128,7 @@ Texture::Texture(SDL_Renderer* window_renderer,
     SDL_GetClipRect(temp_surface, &rect);
     rect.x = x;
     rect.y = y;
-    texture = SDL_CreateTextureFromSurface(this->window_renderer, temp_surface);
+    texture = SDL_CreateTextureFromSurface(app->get_window_renderer(), temp_surface);
     if(!texture) {
         throw Exception("Não foi possível criar a textura do texto " + text, SDL_GetError());
     }
@@ -142,7 +143,7 @@ Texture::~Texture() {
 
 //-----------------------------------------------------------------------------
 void Texture::render() {
-    SDL_RenderCopy(window_renderer, texture, NULL, &rect);
+    SDL_RenderCopy(app->get_window_renderer(), texture, NULL, &rect);
 }
 
 //-----------------------------------------------------------------------------
@@ -187,8 +188,8 @@ void Texture::set_color(Uint8 r, Uint8 g, Uint8 b) {
 //-----------------------------------------------------------------------------
 //- Rectangle -----------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Rectangle::Rectangle(SDL_Renderer* window_renderer, const SDL_Rect &rect, const SDL_Color &color, bool fill) 
-    : Render(window_renderer) {        
+Rectangle::Rectangle(App *app, const SDL_Rect &rect, const SDL_Color &color, bool fill) 
+    : Render(app) {        
     this->rect = rect;
     this->color = color;
     this->fill = fill;
@@ -201,11 +202,11 @@ Rectangle::~Rectangle() {
 
 //-----------------------------------------------------------------------------
 void Rectangle::render() {
-    SDL_SetRenderDrawColor(window_renderer, color.r, color.g, color.b, color.a);
+    SDL_SetRenderDrawColor(app->get_window_renderer(), color.r, color.g, color.b, color.a);
     if(fill) {
-        SDL_RenderFillRect(window_renderer, &rect);   
+        SDL_RenderFillRect(app->get_window_renderer(), &rect);   
     } else {
-        SDL_RenderDrawRect(window_renderer, &rect);   
+        SDL_RenderDrawRect(app->get_window_renderer(), &rect);   
     }
     
 }
@@ -238,8 +239,8 @@ void Rectangle::get_rect(SDL_Rect &rect) const {
 //-----------------------------------------------------------------------------
 //- Line ----------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Line::Line(SDL_Renderer* window_renderer, const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color) 
-    : Render(window_renderer) {
+Line::Line(App *app, const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color) 
+    : Render(app) {
     this->point1 = point1;
     this->point2 = point2;
     this->color = color;
@@ -251,8 +252,8 @@ Line::~Line() {
 }
 //-----------------------------------------------------------------------------
 void Line::render(void) {
-    SDL_SetRenderDrawColor(window_renderer, color.r, color.g, color.b, color.a);      
-    SDL_RenderDrawLine(window_renderer, point1.x, point1.y, point2.x, point2.y); 
+    SDL_SetRenderDrawColor(app->get_window_renderer(), color.r, color.g, color.b, color.a);      
+    SDL_RenderDrawLine(app->get_window_renderer(), point1.x, point1.y, point2.x, point2.y); 
 }
 //-----------------------------------------------------------------------------
 void Line::set_x(int x) {
@@ -285,8 +286,8 @@ void Line::get_rect(SDL_Rect &rect) const {
 //-----------------------------------------------------------------------------
 //- Lines ---------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Lines::Lines(SDL_Renderer* window_renderer, const vector<SDL_Point> &points, const SDL_Color &color) 
-    : Render(window_renderer) {
+Lines::Lines(App *app, const vector<SDL_Point> &points, const SDL_Color &color) 
+    : Render(app) {
     this->points = points;
     this->color = color;
 }
@@ -298,8 +299,8 @@ Lines::~Lines() {
 
 //-----------------------------------------------------------------------------
 void Lines::render(void) {
-    SDL_SetRenderDrawColor(window_renderer, color.r, color.g, color.b, color.a);      
-    SDL_RenderDrawLines(window_renderer, points.data(), points.size()); 
+    SDL_SetRenderDrawColor(app->get_window_renderer(), color.r, color.g, color.b, color.a);      
+    SDL_RenderDrawLines(app->get_window_renderer(), points.data(), points.size()); 
 }
 
 //-----------------------------------------------------------------------------
@@ -353,8 +354,8 @@ void Lines::get_rect(SDL_Rect &rect) const {
 //-----------------------------------------------------------------------------
 //- Point ---------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Point::Point(SDL_Renderer* window_renderer, const SDL_Point &point, const SDL_Color &color) 
-    : Render(window_renderer) {
+Point::Point(App *app, const SDL_Point &point, const SDL_Color &color) 
+    : Render(app) {
     this->point = point;
     this->color = color;
 }
@@ -365,8 +366,8 @@ Point::~Point() {
 }
 //-----------------------------------------------------------------------------
 void Point::render(void) {
-    SDL_SetRenderDrawColor(window_renderer, color.r, color.g, color.b, color.a);      
-    SDL_RenderDrawPoint(window_renderer, point.x, point.y);  
+    SDL_SetRenderDrawColor(app->get_window_renderer(), color.r, color.g, color.b, color.a);      
+    SDL_RenderDrawPoint(app->get_window_renderer(), point.x, point.y);  
 }
 
 //-----------------------------------------------------------------------------
@@ -396,8 +397,8 @@ void Point::get_rect(SDL_Rect &rect) const {
 //-----------------------------------------------------------------------------
 //- Rectangles ----------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Rectangles::Rectangles(SDL_Renderer* window_renderer, const vector<SDL_Rect>&rects, const SDL_Color &color, bool fill) 
-    : Render(window_renderer) {
+Rectangles::Rectangles(App *app, const vector<SDL_Rect>&rects, const SDL_Color &color, bool fill) 
+    : Render(app) {
     this->rects = rects;
     this->color = color;
     this->fill = fill;
@@ -408,11 +409,11 @@ Rectangles::~Rectangles() {
 }
 //-----------------------------------------------------------------------------
 void Rectangles::render(void) {
-    SDL_SetRenderDrawColor(window_renderer, color.r, color.g, color.b, color.a);      
+    SDL_SetRenderDrawColor(app->get_window_renderer(), color.r, color.g, color.b, color.a);      
     if(fill) {
-        SDL_RenderFillRects(window_renderer, rects.data(), rects.size());   
+        SDL_RenderFillRects(app->get_window_renderer(), rects.data(), rects.size());   
     } else {
-        SDL_RenderDrawRects(window_renderer, rects.data(), rects.size());   
+        SDL_RenderDrawRects(app->get_window_renderer(), rects.data(), rects.size());   
     }
 }
 
@@ -476,8 +477,8 @@ void Rectangles::get_rect(SDL_Rect &rect) const {
 //-----------------------------------------------------------------------------
 //- Points --------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Points::Points(SDL_Renderer* window_renderer, const vector<SDL_Point>&points, const SDL_Color &color) 
-    : Render(window_renderer) {
+Points::Points(App *app, const vector<SDL_Point>&points, const SDL_Color &color) 
+    : Render(app) {
     this->points = points;
     this->color = color;
 }
@@ -489,8 +490,8 @@ Points::~Points() {
 
 //-----------------------------------------------------------------------------
 void Points::render(void) {
-    SDL_SetRenderDrawColor(window_renderer, color.r, color.g, color.b, color.a);      
-    SDL_RenderDrawPoints(window_renderer, points.data(), points.size());  
+    SDL_SetRenderDrawColor(app->get_window_renderer(), color.r, color.g, color.b, color.a);      
+    SDL_RenderDrawPoints(app->get_window_renderer(), points.data(), points.size());  
 }
 
 //-----------------------------------------------------------------------------
@@ -543,12 +544,12 @@ void Points::get_rect(SDL_Rect &rect) const {
 //-----------------------------------------------------------------------------
 //- Grid ----------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-Grid::Grid(SDL_Renderer* window_renderer, 
+Grid::Grid(App *app, 
            int cols, int rows, int col_size, 
            int row_size, int vline_size, int hline_size,
            int vpad, int hpad,
            const SDL_Color &color)
-    : Rectangles(window_renderer, vector<SDL_Rect>(), color, true) {
+    : Rectangles(app, vector<SDL_Rect>(), color, true) {
 
     this->cols = cols;
     this->rows = rows;
@@ -590,7 +591,7 @@ void Grid::get_cell_rect(int col, int row, SDL_Rect &rect) const {
 Rectangle *Grid::add_retangle(int col, int row, const SDL_Color &color, bool fill) {
     SDL_Rect rect;
     get_cell_rect(col, row, rect);
-    Rectangle *p = new Rectangle(window_renderer, rect, color, fill);
+    Rectangle *p = new Rectangle(app, rect, color, fill);
     renders.push_back(p);
     map_renders[col][row] = p;
     p->owner = this;
@@ -601,7 +602,7 @@ Rectangle *Grid::add_retangle(int col, int row, const SDL_Color &color, bool fil
 Texture *Grid::add_texture(int col, int row, const string& file_name) { 
     SDL_Rect rect;
     get_cell_rect(col, row, rect);    
-    Texture *p = new Texture(window_renderer, file_name, rect.x, rect.y);
+    Texture *p = new Texture(app, file_name, rect.x, rect.y);
     renders.push_back(p);
     map_renders[col][row] = p;
     p->owner = this;
@@ -726,5 +727,16 @@ bool Grid::get_render_cell(const Render *render, int &col, int &row) const {
         }
     }
     return false;
+}
+
+//-----------------------------------------------------------------------------
+Render *Grid::add_render(int col, int row, Render *render) {
+    SDL_Rect rect;
+    get_cell_rect(col, row, rect);
+    render->set_xy(rect.x, rect.y);
+    renders.push_back(render);
+    map_renders[col][row] = render;
+    render->owner = this;
+    return render;
 }
 

--- a/render.hpp
+++ b/render.hpp
@@ -10,6 +10,7 @@
 
 using namespace std;
 
+class App;
 class Render;
 
 typedef vector<Render*> Renders;
@@ -21,12 +22,12 @@ void inflate_rect(SDL_Rect &rect, int amount);
 
 class Render {
 protected:
-    SDL_Renderer* window_renderer;
     Renders renders;
 public:
-    Render(SDL_Renderer* window_renderer);
+    Render(App *app);
     virtual ~Render();
 public:
+    App *app;
     Render *owner;
     SDL_Color color;
     virtual void render(void) = 0;
@@ -51,8 +52,8 @@ public:
 
 class Texture : public Render {
 public:
-    Texture(SDL_Renderer* window_renderer, const string& file_name, int x, int y);
-    Texture(SDL_Renderer* window_renderer, 
+    Texture(App *app, const string& file_name, int x, int y);
+    Texture(App *app, 
             const string& ttf_file_name, 
             const string& text,
             int x, int y, 
@@ -76,7 +77,7 @@ private:
 
 class Rectangle : public Render {
 public:
-    Rectangle(SDL_Renderer* window_renderer, const SDL_Rect &rect, const SDL_Color &color, bool fill);
+    Rectangle(App *app, const SDL_Rect &rect, const SDL_Color &color, bool fill);
     ~Rectangle();
 public:
     SDL_Rect rect;
@@ -91,7 +92,7 @@ private:
 
 class Rectangles : public Render {
 public:
-    Rectangles(SDL_Renderer* window_renderer, const vector<SDL_Rect>&rects, const SDL_Color &color, bool fill);
+    Rectangles(App *app, const vector<SDL_Rect>&rects, const SDL_Color &color, bool fill);
     ~Rectangles();
 public:
     void render(void);
@@ -108,7 +109,7 @@ private:
 
 class Line : public Render {
 public:
-    Line(SDL_Renderer* window_renderer, const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color);
+    Line(App *app, const SDL_Point &point1, const SDL_Point &point2, const SDL_Color &color);
     ~Line();
 public:
     SDL_Point point1, point2;
@@ -121,7 +122,7 @@ public:
 
 class Lines : public Render {
 public:
-    Lines(SDL_Renderer* window_renderer, const vector<SDL_Point> &points, const SDL_Color &color);
+    Lines(App *app, const vector<SDL_Point> &points, const SDL_Color &color);
     ~Lines();
 public:
     void render(void);
@@ -135,7 +136,7 @@ private:
 
 class Point : public Render {
 public:
-    Point(SDL_Renderer* window_renderer, const SDL_Point &point, const SDL_Color &color);
+    Point(App *app, const SDL_Point &point, const SDL_Color &color);
     ~Point();
 public:
     SDL_Point point;
@@ -148,7 +149,7 @@ public:
 
 class Points : public Render {
 public:
-    Points(SDL_Renderer* window_renderer, const vector<SDL_Point>&points, const SDL_Color &color);
+    Points(App *app, const vector<SDL_Point>&points, const SDL_Color &color);
     ~Points();
 public:
     void render(void);
@@ -162,7 +163,7 @@ private:
 
 class Grid : public Rectangles {
 public:
-    Grid(SDL_Renderer* window_renderer, 
+    Grid(App *app, 
          int cols, int rows, int col_size, 
          int row_size, int vline_size, int hline_size,
          int vpad, int hpad,
@@ -176,6 +177,7 @@ public:
     Render *remove_render(Render *render);
     bool get_render_cell(const Render *render, int &col, int &row) const;
     Render *get_render(int col, int row);
+    Render *add_render(int col, int row, Render *render);
 public:
     void render(void);    
     void set_x(int x);


### PR DESCRIPTION
Agora ao invés de passar `SDL_Renderer` no constructor dos renderes, será passado o App. Com isso será possível que um render acesse outros renders, possibilitando a interação entre eles