### PR TITLE
Rotacionando cartas com threads

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -60,9 +60,9 @@ void App::loop(void) {
             switch(e.type) {
                 case SDL_QUIT:
                     quit = true;
-            }
-            render();
+            }            
         }
+        render();
     }    
 }
 

--- a/app.hpp
+++ b/app.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
+//#include <SDL_thread.h>
 #include "render.hpp"
 #include "card.hpp"
 

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -13,33 +13,42 @@ Cacheta::Cacheta() : App("Cacheta 1.0", 800, 600) {
 
     Texture *btn1 = add_texture_text(
         "28 Days Later.ttf", 
-        "DIREITA", 
-        10, 10, {0x00, 0x00, 0xFF, 0xFF}, 48
+        "SELECIONE ALGUMAS CARTAS PARA O GIRO 360", 
+        10, 10, {0x00, 0x00, 0xFF, 0xFF}, 36
     );
     void (*btn1_click)(Render*) = [](Render *r) {
+
+        auto thread_function = [](void *r) {
+            Card *card = (Card*)r;
+            double rotate = 0;
+            while(rotate<360) {            
+                card->rotate(rotate += 0.000001f);            
+            }
+            return 0;
+        };
+
         App *app = r->app;
         CardGroup *group = dynamic_cast<CardGroup*>(app->renders[0]);
         Cards cards = group->get_selecteds();
         for(int i = 0; i < cards.size(); i++) {
-            cards[i]->inc_rotate(6);
+            SDL_Thread* thread;
+            thread = SDL_CreateThread( thread_function, "LoopThread", (void*)cards[i]);
         }
     };
     btn1->on_mouse_click = btn1_click;
 
-    Texture *btn2 = add_texture_text(
-        "28 Days Later.ttf", 
-        "ESQUERDA", 
-        350, 10, {0xFF, 0x00, 0x00, 0xFF}, 48
-    );
-    void (*btn2_click)(Render*) = [](Render *r) {
-        App *app = r->app;
-        CardGroup *group = dynamic_cast<CardGroup*>(app->renders[0]);
-        Cards cards = group->get_selecteds();
-        for(int i = 0; i < cards.size(); i++) {
-            cards[i]->inc_rotate(-6);
+    
+    auto thread_function = [](void *r) {
+        Card *card = (Card*)r;
+        while(true) {            
+            card->inc_rotate(0.000001f);            
         }
+        return 0;
     };
-    btn2->on_mouse_click = btn2_click;
+
+    Cards cards = group_1->get_cards();
+    SDL_Thread* thread;
+    thread = SDL_CreateThread( thread_function, "CachetaThread", (void*)cards[12]);
 
 }
 

--- a/cacheta.cpp
+++ b/cacheta.cpp
@@ -19,21 +19,22 @@ Cacheta::Cacheta() : App("Cacheta 1.0", 800, 600) {
     void (*btn1_click)(Render*) = [](Render *r) {
 
         auto thread_function = [](void *r) {
-            Card *card = (Card*)r;
+            Cards *cards = (Cards*)r;
             double rotate = 0;
-            while(rotate<360) {            
-                card->rotate(rotate += 0.000001f);            
+            while(rotate<360) { 
+                for(int i = 0; i < cards->size(); i++) {
+                    (*cards)[i]->rotate(rotate += 0.000006f);            
+                }                
             }
+            delete cards;
             return 0;
         };
 
         App *app = r->app;
         CardGroup *group = dynamic_cast<CardGroup*>(app->renders[0]);
-        Cards cards = group->get_selecteds();
-        for(int i = 0; i < cards.size(); i++) {
-            SDL_Thread* thread;
-            thread = SDL_CreateThread( thread_function, "LoopThread", (void*)cards[i]);
-        }
+        Cards *cards = new Cards(group->get_selecteds());
+        SDL_Thread* thread;
+        thread = SDL_CreateThread( thread_function, "LoopThread", (void*)cards);
     };
     btn1->on_mouse_click = btn1_click;
 


### PR DESCRIPTION
Não foi programado nas classes, ainda estou pensando em como fazer isso. Mas este pull demonstra como animar com threads.
A única coisa importante, e por isso estou enviando a branch, é a troca de lugar do `render();`, que funcionava até o momento, mas ao introduzir as threads precisou ser trocado de lugar.

Em cacheta 2 exemplos de uso, um com thread finita (giro 360) e outro infinita (giro eterno).

Selecione a carta girando e aplique o giro 360 para ver o que acontece (as thread modificando um mesmo objeto).